### PR TITLE
Fixed an issue with dnn-image-crop not working in safari

### DIFF
--- a/src/components/dnn-image-cropper/dnn-image-cropper.tsx
+++ b/src/components/dnn-image-cropper/dnn-image-cropper.tsx
@@ -393,13 +393,15 @@ export class DnnImageCropper {
       movementX = event.movementX;
       movementY = event.movementY;
     }
-    if (event instanceof TouchEvent) {
-      let touch = event.touches[0];
-      if (this.previousTouch != undefined) {
-        movementX = touch.pageX - this.previousTouch.pageX;
-        movementY = touch.pageY - this.previousTouch.pageY;
+    if (typeof TouchEvent !== "undefined"){
+      if (event instanceof TouchEvent) {
+        let touch = event.touches[0];
+        if (this.previousTouch != undefined) {
+          movementX = touch.pageX - this.previousTouch.pageX;
+          movementY = touch.pageY - this.previousTouch.pageY;
+        }
+        this.previousTouch = touch;
       }
-      this.previousTouch = touch;
     }
     return { movementX, movementY };
   }


### PR DESCRIPTION
Safari and IE are the only browsers that do not support TouchEvent, this PR does a check for the existance of that interface before using it.