### PR TITLE
Implemented material icons package

### DIFF
--- a/licenses.txt
+++ b/licenses.txt
@@ -332,6 +332,11 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\node_modules\@jest\types
 │  └─ licenseFile: D:\dnn-elements\node_modules\@jest\types\LICENSE
+├─ @material-design-icons/svg@0.10.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/marella/material-design-icons
+│  ├─ path: D:\dnn-elements\node_modules\@material-design-icons\svg
+│  └─ licenseFile: D:\dnn-elements\node_modules\@material-design-icons\svg\LICENSE
 ├─ @sinonjs/commons@1.8.3
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/sinonjs/commons
@@ -3169,6 +3174,12 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\node_modules\static-extend
 │  └─ licenseFile: D:\dnn-elements\node_modules\static-extend\LICENSE
+├─ stencil-inline-svg@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fabriciomendonca/stencil-inline-svg
+│  ├─ publisher: Fabricio Rodrigues
+│  ├─ path: D:\dnn-elements\node_modules\stencil-inline-svg
+│  └─ licenseFile: D:\dnn-elements\node_modules\stencil-inline-svg\LICENSE
 ├─ string-length@4.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/string-length

--- a/package-lock.json
+++ b/package-lock.json
@@ -884,6 +884,12 @@
         }
       }
     },
+    "@material-design-icons/svg": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@material-design-icons/svg/-/svg-0.10.1.tgz",
+      "integrity": "sha512-oRx0waBsnN7XobqRhgNA21Amd0/DsyA7prq6PrChgyd82g5q8o9NLjhb8q0lSxQsnCr+BNs2LKNXa7KCRTO7sA==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6300,6 +6306,12 @@
           }
         }
       }
+    },
+    "stencil-inline-svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stencil-inline-svg/-/stencil-inline-svg-1.1.0.tgz",
+      "integrity": "sha512-couT89xzsoycwHOIAgnl3WBpXaVRQ3ZlUBINo7HsT/AtWaFW9cxGlAzsK2JzkzxK7yUuoeIpdH2fNlvuH06DRg==",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "eslint --ext .ts --ext .tsx --ext .js ./src"
   },
   "devDependencies": {
+    "@material-design-icons/svg": "^0.10.1",
     "@stencil/core": "^2.9.0",
     "@stencil/eslint-plugin": "^0.3.1",
     "@stencil/sass": "^1.5.2",
@@ -40,6 +41,7 @@
     "jest-cli": "^26.6.3",
     "license-checker": "^25.0.1",
     "puppeteer": "^10.0.0",
+    "stencil-inline-svg": "^1.1.0",
     "typescript": "^3.4.3",
     "typescript-debounce-decorator": "^0.0.18"
   },

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -360,6 +360,9 @@ declare namespace LocalJSX {
           * Specifies the jpeg quality for when the device camera is used to generate a picture. Needs to be a number between 0 and 1 and defaults to 0.8
          */
         "captureQuality"?: number;
+        /**
+          * Fires when file were selected.
+         */
         "onFilesSelected"?: (event: CustomEvent<File[]>) => void;
         /**
           * Localization strings

--- a/src/components/dnn-chevron/dnn-chevron.scss
+++ b/src/components/dnn-chevron/dnn-chevron.scss
@@ -14,7 +14,8 @@ button{
   outline: none;
 }
 svg{
-  height:1em;
+  height:2em;
+  width:2em;
   transition: all 300ms ease-in-out;
 }
 

--- a/src/components/dnn-chevron/dnn-chevron.tsx
+++ b/src/components/dnn-chevron/dnn-chevron.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Prop, Event } from '@stencil/core';
 import { EventEmitter } from '@stencil/core';
 import { Watch } from '@stencil/core';
+import chevronRightIcon from "@material-design-icons/svg/filled/chevron_right.svg";
 
 @Component({
   tag: 'dnn-chevron',
@@ -32,7 +33,7 @@ export class DnnChevron {
         <button aria-label={this.expanded ? this.collapseText : this.expandText}
           onClick={() => this.expanded = !this.expanded}
         >
-          <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-right" class="svg-inline--fa fa-chevron-right fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"></path></svg>
+          <div innerHTML={chevronRightIcon} />
         </button>
       </Host>
     );

--- a/src/components/dnn-color-picker/dnn-color-picker.scss
+++ b/src/components/dnn-color-picker/dnn-color-picker.scss
@@ -130,7 +130,8 @@
                 background-color: transparent;
                 border: none;
                 svg {
-                    min-width: 3em;
+                    width: 3em;
+                    height: 3em;
                     pointer-events: none;
                     outline: none;
                 }

--- a/src/components/dnn-color-picker/dnn-color-picker.tsx
+++ b/src/components/dnn-color-picker/dnn-color-picker.tsx
@@ -6,6 +6,8 @@
 import { Component, h, State, Element, Prop, EventEmitter, Event, Watch } from "@stencil/core";
 import { ColorInfo } from '../../utilities/colorInfo';
 import { Debounce } from "../../utilities/debounce";
+import repeatIcon from "@material-design-icons/svg/filled/repeat.svg";
+import contentCopyIcon from "@material-design-icons/svg/filled/content_copy.svg";
 
 /** Color Picker for Dnn */
 @Component({
@@ -356,9 +358,12 @@ export class DnnColorPicker {
                             />
                         </div>
                         <div class="dnn-color-mode-switch">
-                            <button id="rgb-switch" onClick={this.switchColorMode.bind(this)} aria-label="switch to hexadecimal value entry">
-                                <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="retweet" class="svg-inline--fa fa-retweet fa-w-20" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M629.657 343.598L528.971 444.284c-9.373 9.372-24.568 9.372-33.941 0L394.343 343.598c-9.373-9.373-9.373-24.569 0-33.941l10.823-10.823c9.562-9.562 25.133-9.34 34.419.492L480 342.118V160H292.451a24.005 24.005 0 0 1-16.971-7.029l-16-16C244.361 121.851 255.069 96 276.451 96H520c13.255 0 24 10.745 24 24v222.118l40.416-42.792c9.285-9.831 24.856-10.054 34.419-.492l10.823 10.823c9.372 9.372 9.372 24.569-.001 33.941zm-265.138 15.431A23.999 23.999 0 0 0 347.548 352H160V169.881l40.416 42.792c9.286 9.831 24.856 10.054 34.419.491l10.822-10.822c9.373-9.373 9.373-24.569 0-33.941L144.971 67.716c-9.373-9.373-24.569-9.373-33.941 0L10.343 168.402c-9.373 9.373-9.373 24.569 0 33.941l10.822 10.822c9.562 9.562 25.133 9.34 34.419-.491L96 169.881V392c0 13.255 10.745 24 24 24h243.549c21.382 0 32.09-25.851 16.971-40.971l-16.001-16z"/></svg>
-                            </button>
+                            <button
+                                id="rgb-switch"
+                                innerHTML={repeatIcon}
+                                onClick={this.switchColorMode.bind(this)}
+                                aria-label="switch to hexadecimal value entry"
+                            />
                         </div>
                     </div>
                     <div class="dnn-hsl-color-fields" style={{display: this.hslDisplay}}>
@@ -381,9 +386,12 @@ export class DnnColorPicker {
                             />
                         </div>
                         <div class="dnn-color-mode-switch">
-                            <button id="hsl-switch" onClick={this.switchColorMode.bind(this)} aria-label="Sitch to red, green, blue entry mode">
-                                <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="retweet" class="svg-inline--fa fa-retweet fa-w-20" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M629.657 343.598L528.971 444.284c-9.373 9.372-24.568 9.372-33.941 0L394.343 343.598c-9.373-9.373-9.373-24.569 0-33.941l10.823-10.823c9.562-9.562 25.133-9.34 34.419.492L480 342.118V160H292.451a24.005 24.005 0 0 1-16.971-7.029l-16-16C244.361 121.851 255.069 96 276.451 96H520c13.255 0 24 10.745 24 24v222.118l40.416-42.792c9.285-9.831 24.856-10.054 34.419-.492l10.823 10.823c9.372 9.372 9.372 24.569-.001 33.941zm-265.138 15.431A23.999 23.999 0 0 0 347.548 352H160V169.881l40.416 42.792c9.286 9.831 24.856 10.054 34.419.491l10.822-10.822c9.373-9.373 9.373-24.569 0-33.941L144.971 67.716c-9.373-9.373-24.569-9.373-33.941 0L10.343 168.402c-9.373 9.373-9.373 24.569 0 33.941l10.822 10.822c9.562 9.562 25.133 9.34 34.419-.491L96 169.881V392c0 13.255 10.745 24 24 24h243.549c21.382 0 32.09-25.851 16.971-40.971l-16.001-16z"/></svg>
-                            </button>
+                            <button
+                                id="hsl-switch"
+                                innerHTML={repeatIcon}
+                                onClick={this.switchColorMode.bind(this)}
+                                aria-label="Switch to red, green, blue entry mode"
+                            />
                         </div>
                     </div>
                     <div class="dnn-hex-color-fields" style={{display: this.hexDisplay}}>
@@ -394,15 +402,20 @@ export class DnnColorPicker {
                                     value={this.getHex()}
                                     onChange={e => this.handleHexChange((e.target as HTMLInputElement).value)}
                                 />
-                                <button class="copy" aria-label="copy value">
-                                    <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="copy" class="svg-inline--fa fa-copy fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"></path></svg>
-                                </button>
+                                <button
+                                    class="copy"
+                                    innerHTML={contentCopyIcon}
+                                    aria-label="copy value"
+                                />
                             </div>
                         </div>
                         <div class="dnn-color-mode-switch">
-                            <button id="hex-switch" onClick={this.switchColorMode.bind(this)} aria-label="Switch to hue saturation lightness values">
-                                <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="retweet" class="svg-inline--fa fa-retweet fa-w-20" role="img" viewBox="0 0 640 512"><path fill="currentColor" d="M629.657 343.598L528.971 444.284c-9.373 9.372-24.568 9.372-33.941 0L394.343 343.598c-9.373-9.373-9.373-24.569 0-33.941l10.823-10.823c9.562-9.562 25.133-9.34 34.419.492L480 342.118V160H292.451a24.005 24.005 0 0 1-16.971-7.029l-16-16C244.361 121.851 255.069 96 276.451 96H520c13.255 0 24 10.745 24 24v222.118l40.416-42.792c9.285-9.831 24.856-10.054 34.419-.492l10.823 10.823c9.372 9.372 9.372 24.569-.001 33.941zm-265.138 15.431A23.999 23.999 0 0 0 347.548 352H160V169.881l40.416 42.792c9.286 9.831 24.856 10.054 34.419.491l10.822-10.822c9.373-9.373 9.373-24.569 0-33.941L144.971 67.716c-9.373-9.373-24.569-9.373-33.941 0L10.343 168.402c-9.373 9.373-9.373 24.569 0 33.941l10.822 10.822c9.562 9.562 25.133 9.34 34.419-.491L96 169.881V392c0 13.255 10.745 24 24 24h243.549c21.382 0 32.09-25.851 16.971-40.971l-16.001-16z"/></svg>
-                            </button>
+                            <button
+                                id="hex-switch"
+                                innerHTML={repeatIcon}
+                                onClick={this.switchColorMode.bind(this)}
+                                aria-label="Switch to hue saturation lightness values"
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/components/dnn-dropzone/dnn-dropzone.tsx
+++ b/src/components/dnn-dropzone/dnn-dropzone.tsx
@@ -1,4 +1,6 @@
 import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import uploadIcon from "@material-design-icons/svg/filled/upload.svg";
+import photoCameraIcon from "@material-design-icons/svg/filled/photo_camera.svg";
 
 @Component({
   tag: 'dnn-dropzone',
@@ -40,6 +42,7 @@ export class DnnDropzone {
    */
   @Prop() captureQuality: number = 0.8;
 
+  /** Fires when file were selected. */
   @Event() filesSelected: EventEmitter<File[]>;
   
   @State() canTakeSnapshots: boolean = false;
@@ -78,7 +81,7 @@ export class DnnDropzone {
     });
   }
 
-  getFilesFromFileList(files: FileList) : File[] {
+  private getFilesFromFileList(files: FileList) : File[] {
     var fileList: File[] = [];
     for (let index = 0; index < files.length; index++) {
       const file = files[index];
@@ -183,7 +186,7 @@ export class DnnDropzone {
                 onChange={e => this.handleUploadButton(e.target as HTMLInputElement)}
               >
               </input>
-              <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24" /></g><g><path d="M5,20h14v-2H5V20z M5,10h4v6h6v-6h4l-7-7L5,10z" /></g></svg>
+              <span innerHTML={uploadIcon} />&nbsp;
               {this.resx?.uploadFile}
             </label>
             ,
@@ -194,7 +197,7 @@ export class DnnDropzone {
                 <button
                   onClick={() => this.takeSnapshot()}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none" /><circle cx="12" cy="12" r="3.2" /><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z" /></svg>
+                  <span innerHTML={photoCameraIcon} />&nbsp;
                   {this.resx?.takePicture}
                 </button>
               ]
@@ -206,7 +209,7 @@ export class DnnDropzone {
             <button
               onClick={() => this.applySnapshot()}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none" /><circle cx="12" cy="12" r="3.2" /><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z" /></svg>
+              <span innerHTML={photoCameraIcon} />              
               {this.resx?.capture}
             </button>
           </div>

--- a/src/components/dnn-dropzone/readme.md
+++ b/src/components/dnn-dropzone/readme.md
@@ -17,9 +17,9 @@
 
 ## Events
 
-| Event           | Description | Type                  |
-| --------------- | ----------- | --------------------- |
-| `filesSelected` |             | `CustomEvent<File[]>` |
+| Event           | Description                    | Type                  |
+| --------------- | ------------------------------ | --------------------- |
+| `filesSelected` | Fires when file were selected. | `CustomEvent<File[]>` |
 
 
 ## CSS Custom Properties

--- a/src/components/dnn-modal/dnn-modal.tsx
+++ b/src/components/dnn-modal/dnn-modal.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Host, h, Prop, Event, EventEmitter, Method, State } from '@stencil/core';
+import cancelIcon from "@material-design-icons/svg/filled/cancel.svg";
 
 @Component({
   tag: 'dnn-modal',
@@ -71,10 +72,12 @@ export class DnnModal {
         >
           <div class="modal">
             {this.showCloseButton &&
-              <button class="close" aria-label={this.closeText}
-                onClick={() => this.handleDismiss()}>
-                  <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times-circle" class="svg-inline--fa fa-times-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"></path></svg>
-              </button>
+              <button
+                class="close"
+                innerHTML={cancelIcon}
+                aria-label={this.closeText}
+                onClick={() => this.handleDismiss()}
+              />
             }
             <slot></slot>
           </div>

--- a/src/components/dnn-searchbox/dnn-searchbox.tsx
+++ b/src/components/dnn-searchbox/dnn-searchbox.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Event, EventEmitter, Watch, Prop } from '@stencil/core';
 import { Debounce } from '../../utilities/debounce';
-
+import searchIcon from "@material-design-icons/svg/filled/search.svg";
+import cancelIcon from "@material-design-icons/svg/filled/cancel.svg";
 @Component({
   tag: 'dnn-searchbox',
   styleUrl: 'dnn-searchbox.scss',
@@ -56,12 +57,11 @@ export class DnnSearchbox {
         />
         {this.query !== "" ?
           <button class="svg clear"
+            innerHTML={cancelIcon}
             onClick={() => this.query = ""}
-          >
-            <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times-circle" class="svg-inline--fa fa-times-circle fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"></path></svg>
-          </button>
+          />
         :
-        <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="search" class="svg-inline--fa fa-search fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"></path></svg>
+        <span innerHTML={searchIcon} />
         }
       </Host>
     );

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,6 +1,6 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
-
+import { inlineSvg } from "stencil-inline-svg";
 
 export const config: Config = {
   namespace: 'dnn',
@@ -18,7 +18,8 @@ export const config: Config = {
     }
   ],
   plugins: [
-    sass()
+    sass(),
+    inlineSvg(),
   ],
   sourceMap: true
 };


### PR DESCRIPTION
This changes most inline svg icons into the material icons svg npm package.

This is a potential breaking change from consumers of this library as you will either end up with an inline svg or a base64 data-url depending on how this is consumed which may affect how the css works out. In theory because we are in shadow-dom, it should not be an issue but it is worth testing before upgrading to this new version.

For stenciljs consumers of this package you can simply
`npm install stencil-inline-svg --save-dev` and call it in your stencil config plugins, for usage in other frameworks, please open an issue with minimal usage scenario for help.