### PR TITLE
Run TagRelease before Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ UserInterfaceState.xcuserstate
 .vs
 _build/bin
 _build/obj
+.nuke/temp

--- a/_build/Build.cs
+++ b/_build/Build.cs
@@ -151,6 +151,7 @@ class Build : NukeBuild
   Target TagRelease => _ => _
     .OnlyWhenDynamic(() => gitRepository.IsOnMainOrMasterBranch() || gitRepository.IsOnReleaseBranch())
     .OnlyWhenDynamic(() => !string.IsNullOrWhiteSpace(GithubToken))
+    .Before(Compile)
     .DependsOn(SetupGitHubClient)
     .Executes(() =>
     {


### PR DESCRIPTION
This fixes an npm release versioning issue.