### PR TITLE
Fixed an issue that prevented icons from showing on consumers

### DIFF
--- a/licenses.txt
+++ b/licenses.txt
@@ -339,7 +339,7 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\node_modules\@jest\types
 │  └─ licenseFile: D:\dnn-elements\node_modules\@jest\types\LICENSE
-├─ @material-design-icons/svg@0.10.4
+├─ @material-design-icons/svg@0.10.5
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/marella/material-design-icons
 │  ├─ path: D:\dnn-elements\node_modules\@material-design-icons\svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -853,10 +853,9 @@
       }
     },
     "@material-design-icons/svg": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@material-design-icons/svg/-/svg-0.10.4.tgz",
-      "integrity": "sha512-NLxE0H4zX/LEjPxJ+DRR/7FOUrY7cpPgW7DbK5Ux7KmJixN2y8q9oHR/3bS31KuLTt8/AEP8InycjViQGbb7cg==",
-      "dev": true
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@material-design-icons/svg/-/svg-0.10.5.tgz",
+      "integrity": "sha512-BosZndzOgW1wclEQQYuy0eCAnADyhxdhWOUDP+AMv+C8obLzaPS8ze2QXBoDXyTaLnHRhGfpTMTYW3cofpIe1Q=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint": "eslint --ext .ts --ext .tsx --ext .js ./src"
   },
   "devDependencies": {
-    "@material-design-icons/svg": "^0.10.1",
     "@stencil/core": "^2.9.0",
     "@stencil/eslint-plugin": "^0.4.0",
     "@stencil/sass": "^1.5.2",
@@ -45,5 +44,8 @@
     "typescript": "^4.5.4",
     "typescript-debounce-decorator": "^0.0.18"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@material-design-icons/svg": "^0.10.5"
+  }
 }


### PR DESCRIPTION
- Moved material design icons package from `dev-dependencies` to `dependencies`
- Bumped from v0.10.1 to v0.10.5

Closes #417