### PR TITLE
Removed stencil-inline-svg due to a bug

### DIFF
--- a/licenses.txt
+++ b/licenses.txt
@@ -339,11 +339,6 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\node_modules\@jest\types
 │  └─ licenseFile: D:\dnn-elements\node_modules\@jest\types\LICENSE
-├─ @material-design-icons/svg@0.10.5
-│  ├─ licenses: Apache-2.0
-│  ├─ repository: https://github.com/marella/material-design-icons
-│  ├─ path: D:\dnn-elements\node_modules\@material-design-icons\svg
-│  └─ licenseFile: D:\dnn-elements\node_modules\@material-design-icons\svg\LICENSE
 ├─ @nodelib/fs.scandir@2.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
@@ -3280,12 +3275,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\node_modules\static-extend
 │  └─ licenseFile: D:\dnn-elements\node_modules\static-extend\LICENSE
-├─ stencil-inline-svg@1.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/fabriciomendonca/stencil-inline-svg
-│  ├─ publisher: Fabricio Rodrigues
-│  ├─ path: D:\dnn-elements\node_modules\stencil-inline-svg
-│  └─ licenseFile: D:\dnn-elements\node_modules\stencil-inline-svg\LICENSE
 ├─ string-length@4.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/string-length

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,11 +852,6 @@
         }
       }
     },
-    "@material-design-icons/svg": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@material-design-icons/svg/-/svg-0.10.5.tgz",
-      "integrity": "sha512-BosZndzOgW1wclEQQYuy0eCAnADyhxdhWOUDP+AMv+C8obLzaPS8ze2QXBoDXyTaLnHRhGfpTMTYW3cofpIe1Q=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7950,12 +7945,6 @@
           }
         }
       }
-    },
-    "stencil-inline-svg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stencil-inline-svg/-/stencil-inline-svg-1.1.0.tgz",
-      "integrity": "sha512-couT89xzsoycwHOIAgnl3WBpXaVRQ3ZlUBINo7HsT/AtWaFW9cxGlAzsK2JzkzxK7yUuoeIpdH2fNlvuH06DRg==",
-      "dev": true
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,9 @@
     "jest-cli": "^26.6.3",
     "license-checker": "^25.0.1",
     "puppeteer": "^13.0.1",
-    "stencil-inline-svg": "^1.1.0",
     "typescript": "^4.5.4",
     "typescript-debounce-decorator": "^0.0.18"
   },
   "license": "MIT",
-  "dependencies": {
-    "@material-design-icons/svg": "^0.10.5"
-  }
+  "dependencies": {}
 }

--- a/src/components/dnn-chevron/dnn-chevron.tsx
+++ b/src/components/dnn-chevron/dnn-chevron.tsx
@@ -1,7 +1,6 @@
 import { Component, Host, h, Prop, Event } from '@stencil/core';
 import { EventEmitter } from '@stencil/core';
 import { Watch } from '@stencil/core';
-import chevronRightIcon from "@material-design-icons/svg/filled/chevron_right.svg";
 
 @Component({
   tag: 'dnn-chevron',
@@ -33,7 +32,7 @@ export class DnnChevron {
         <button aria-label={this.expanded ? this.collapseText : this.expandText}
           onClick={() => this.expanded = !this.expanded}
         >
-          <div innerHTML={chevronRightIcon} />
+          <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
         </button>
       </Host>
     );

--- a/src/components/dnn-color-picker/dnn-color-picker.tsx
+++ b/src/components/dnn-color-picker/dnn-color-picker.tsx
@@ -6,8 +6,6 @@
 import { Component, h, State, Element, Prop, EventEmitter, Event, Watch } from "@stencil/core";
 import { ColorInfo } from '../../utilities/colorInfo';
 import { Debounce } from "../../utilities/debounce";
-import repeatIcon from "@material-design-icons/svg/filled/repeat.svg";
-import contentCopyIcon from "@material-design-icons/svg/filled/content_copy.svg";
 
 /** Color Picker for Dnn */
 @Component({
@@ -360,10 +358,11 @@ export class DnnColorPicker {
                         <div class="dnn-color-mode-switch">
                             <button
                                 id="rgb-switch"
-                                innerHTML={repeatIcon}
                                 onClick={this.switchColorMode.bind(this)}
                                 aria-label="switch to hexadecimal value entry"
-                            />
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/></svg>
+                            </button>
                         </div>
                     </div>
                     <div class="dnn-hsl-color-fields" style={{display: this.hslDisplay}}>
@@ -388,10 +387,11 @@ export class DnnColorPicker {
                         <div class="dnn-color-mode-switch">
                             <button
                                 id="hsl-switch"
-                                innerHTML={repeatIcon}
                                 onClick={this.switchColorMode.bind(this)}
                                 aria-label="Switch to red, green, blue entry mode"
-                            />
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/></svg>
+                            </button>
                         </div>
                     </div>
                     <div class="dnn-hex-color-fields" style={{display: this.hexDisplay}}>
@@ -404,18 +404,20 @@ export class DnnColorPicker {
                                 />
                                 <button
                                     class="copy"
-                                    innerHTML={contentCopyIcon}
                                     aria-label="copy value"
-                                />
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+                                </button>
                             </div>
                         </div>
                         <div class="dnn-color-mode-switch">
                             <button
                                 id="hex-switch"
-                                innerHTML={repeatIcon}
                                 onClick={this.switchColorMode.bind(this)}
                                 aria-label="Switch to hue saturation lightness values"
-                            />
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4z"/></svg>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/src/components/dnn-dropzone/dnn-dropzone.tsx
+++ b/src/components/dnn-dropzone/dnn-dropzone.tsx
@@ -1,6 +1,4 @@
 import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/core';
-import uploadIcon from "@material-design-icons/svg/filled/upload.svg";
-import photoCameraIcon from "@material-design-icons/svg/filled/photo_camera.svg";
 
 @Component({
   tag: 'dnn-dropzone',
@@ -186,7 +184,10 @@ export class DnnDropzone {
                 onChange={e => this.handleUploadButton(e.target as HTMLInputElement)}
               >
               </input>
-              <span innerHTML={uploadIcon} />&nbsp;
+              <span>
+                <svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/></g><g><path d="M5,20h14v-2H5V20z M5,10h4v6h6v-6h4l-7-7L5,10z"/></g></svg>
+              </span>
+              &nbsp;
               {this.resx?.uploadFile}
             </label>
             ,
@@ -197,7 +198,7 @@ export class DnnDropzone {
                 <button
                   onClick={() => this.takeSnapshot()}
                 >
-                  <span innerHTML={photoCameraIcon} />&nbsp;
+                  <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/></svg>
                   {this.resx?.takePicture}
                 </button>
               ]
@@ -209,7 +210,7 @@ export class DnnDropzone {
             <button
               onClick={() => this.applySnapshot()}
             >
-              <span innerHTML={photoCameraIcon} />              
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><circle cx="12" cy="12" r="3.2"/><path d="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z"/></svg>&nbsp;
               {this.resx?.capture}
             </button>
           </div>

--- a/src/components/dnn-modal/dnn-modal.tsx
+++ b/src/components/dnn-modal/dnn-modal.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Host, h, Prop, Event, EventEmitter, Method, State } from '@stencil/core';
-import cancelIcon from "@material-design-icons/svg/filled/cancel.svg";
 
 @Component({
   tag: 'dnn-modal',
@@ -74,10 +73,11 @@ export class DnnModal {
             {this.showCloseButton &&
               <button
                 class="close"
-                innerHTML={cancelIcon}
                 aria-label={this.closeText}
                 onClick={() => this.handleDismiss()}
-              />
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/></svg>
+              </button>
             }
             <slot></slot>
           </div>

--- a/src/components/dnn-searchbox/dnn-searchbox.tsx
+++ b/src/components/dnn-searchbox/dnn-searchbox.tsx
@@ -1,7 +1,5 @@
 import { Component, Host, h, Event, EventEmitter, Watch, Prop } from '@stencil/core';
 import { Debounce } from '../../utilities/debounce';
-import searchIcon from "@material-design-icons/svg/filled/search.svg";
-import cancelIcon from "@material-design-icons/svg/filled/cancel.svg";
 @Component({
   tag: 'dnn-searchbox',
   styleUrl: 'dnn-searchbox.scss',
@@ -57,11 +55,12 @@ export class DnnSearchbox {
         />
         {this.query !== "" ?
           <button class="svg clear"
-            innerHTML={cancelIcon}
             onClick={() => this.query = ""}
-          />
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"/></svg>
+          </button>
         :
-        <span innerHTML={searchIcon} />
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
         }
       </Host>
     );

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,6 +1,5 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
-import { inlineSvg } from "stencil-inline-svg";
 
 export const config: Config = {
   namespace: 'dnn',
@@ -19,7 +18,6 @@ export const config: Config = {
   ],
   plugins: [
     sass(),
-    inlineSvg(),
   ],
   sourceMap: true
 };


### PR DESCRIPTION
Consumers of this package would have to do something special on their hand and since these components need to be universal, I do not want this situation.

This PR removes the svg module and the inline-svg bundling and brings back normal svgs inline in the render method.

This feature might come back if https://github.com/fabriciomendonca/stencil-inline-svg/issues/5 gets resolved.