### PR TITLE
Fixed an issue that prevented cropping images on firefox

### DIFF
--- a/src/components/dnn-image-cropper/dnn-image-cropper.tsx
+++ b/src/components/dnn-image-cropper/dnn-image-cropper.tsx
@@ -90,11 +90,11 @@ export class DnnImageCropper {
   }
 
   private setImage(){
-    this.image.src = this.canvas.toDataURL();
-    window.requestAnimationFrame(() => {
+    this.image.addEventListener('load', () => {
       this.initCrop();
       this.emitImage();
-    });
+    })
+    this.image.src = this.canvas.toDataURL();
   }
 
   private handleNewFile(file: File): void {
@@ -402,10 +402,12 @@ export class DnnImageCropper {
       mouseY = event.clientY;
     }
 
-    if (event instanceof TouchEvent){
-      var touch = event.touches[0];
-      mouseX = touch.clientX;
-      mouseY = touch.clientY;
+    if (typeof TouchEvent !== "undefined"){
+      if (event instanceof TouchEvent){
+        var touch = event.touches[0];
+        mouseX = touch.clientX;
+        mouseY = touch.clientY;
+      }
     }
     
     if (


### PR DESCRIPTION
TouchEvent is not supported on firefox which caused the dragging code to fail. Also changing an image src to a data-url is not instant in firefox so had to attach a load event on it to run the logic only after the image is fully loaded.