### PR TITLE
Improved corner grap capability

### DIFF
--- a/src/components/dnn-image-cropper/dnn-image-cropper.tsx
+++ b/src/components/dnn-image-cropper/dnn-image-cropper.tsx
@@ -393,6 +393,7 @@ export class DnnImageCropper {
   }
 
   private isMouseStillInTarget(event: MouseEvent | TouchEvent) {
+    var inside = false;
     let mouseX: number;
     let mouseY: number;
     const imageRect = this.image.getBoundingClientRect();
@@ -409,15 +410,28 @@ export class DnnImageCropper {
     }
     
     if (
-      mouseX < imageRect.x ||
-      mouseY < imageRect.y ||
-      mouseX > imageRect.left + imageRect.width ||
-      mouseY > imageRect.top + imageRect.height)
+      mouseX >= imageRect.x &&
+      mouseY >= imageRect.y &&
+      mouseX <= imageRect.left + imageRect.width &&
+      mouseY <= imageRect.top + imageRect.height)
     {
-      return false;
+      inside = true;
     }
 
-    return true;
+    var corners = this.crop.querySelectorAll("div");
+    corners.forEach(corner =>{
+      var cornerRect = corner.getBoundingClientRect();
+      if (
+        mouseX >= cornerRect.x &&
+        mouseY >= cornerRect.y &&
+        mouseX <= cornerRect.left + cornerRect.width &&
+        mouseY <= cornerRect.top + cornerRect.height)
+        {
+          inside = true;
+        }
+    })
+
+    return inside;
   }
 
   render() {


### PR DESCRIPTION
Before this change the crop corner could be partially outside the image which would disable the drag. This makes it so if the mouse is outside the image but still inside of a corner of the cropper, it still works and makes it easier to grab.