### PR TITLE
Fixed an issue where CI would not change package version

### DIFF
--- a/_build/Build.cs
+++ b/_build/Build.cs
@@ -106,8 +106,8 @@ class Build : NukeBuild
           }
         }
       };
-      NpmInstall();
       Npm($"version {GitVersion.SemVer} --allow-same-version --git-tag-version false");
+      NpmInstall();
       NpmRun(s => s.SetCommand("build"));
       NpmRun(s => s.SetCommand("test"));
     });
@@ -215,6 +215,7 @@ class Build : NukeBuild
     .DependsOn(SetupGitHubClient)
     .DependsOn(GenerateReleaseNotes)
     .DependsOn(TagRelease)
+    .DependsOn(Compile)
     .Executes(() =>
     {
       var newRelease = new NewRelease(gitRepository.IsOnMainOrMasterBranch() ? $"v{GitVersion.MajorMinorPatch}" : $"v{GitVersion.SemVer}")


### PR DESCRIPTION
The Tag target could fire up in any order, this makes it always run before compile and the deploy task depend on compile too so the build is tested before deployment.

Closes #423 